### PR TITLE
add compressionLevel option to constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,14 +43,25 @@ const validateOptions = ({fromBucket, fromPath}) => {
 
 module.exports = (storage) => (options) => {
     validateOptions(options);
-    const {fromBucket, fromPath, toBucket, toPath, keep, mapper, metadata, progress, downloadValidation} = options;
+    const {
+        fromBucket,
+        fromPath,
+        toBucket,
+        toPath,
+        keep,
+        mapper,
+        metadata,
+        progress,
+        downloadValidation,
+        compressionLevel = 2
+    } = options;
 
     if ((!keep) && (!toBucket)) {
         return Promise.resolve(null);
     }
     const manifest = [];
     
-    const zip = archiver('zip', {zlib: { level: 9 }});
+    const zip = archiver('zip', {zlib: { level: compressionLevel }});
     zip.on('error', (e)=>{ throw e; });
 
     let keepPromise;


### PR DESCRIPTION
This PR to include compressionLevel parameter for zlib. We don’t really need compression level 9, since compression algorithms don’t really compress jpg images, but consume a lot of time trying to do that. being said compression level 3 according to performance benchmarks doesn’t really increase the processing time comparing to no compression but is dramatically faster than compression level 9.
![image](https://user-images.githubusercontent.com/60673142/129787701-3db9434c-6064-4e02-8f7b-2e374e61b639.png)
