### PR TITLE
[SECENG-364] Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  commit-message:
+    prefix: "[bot] "
+  cooldown:
+    default-days: 7
+  schedule:
+    interval: "weekly"
+    day: "wednesday"
+    time: "11:00"
+    timezone: "America/Los_Angeles"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,11 +36,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@231aa2c8a89117b126725a0e11897209b7118144 # v1
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -51,7 +51,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@231aa2c8a89117b126725a0e11897209b7118144 # v1
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -65,4 +65,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@231aa2c8a89117b126725a0e11897209b7118144 # v1

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
@@ -30,4 +30,3 @@ jobs:
     - run: echo "${{ secrets.SERVICE_ACCOUNT }}" | gpg --quiet --batch --yes --decrypt --passphrase="${{ secrets.KEY }}" --output test-storage.json
     - run: npm test
     - run: rm -f ./test-storage.json
-

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -20,9 +20,9 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'


### PR DESCRIPTION
## Ticket
[SECENG-364](https://hoverinc.atlassian.net/browse/SECENG-364)

## Summary

Pin all external GitHub Actions to commit SHAs for supply chain security. Internal (hoverinc/) actions are left unpinned.

### Pinned Actions

  - `actions/checkout@v2` → [`ee0669bd`](https://github.com/actions/checkout/commit/ee0669bd1cc54295c223e0bb666b733df41de1c5)
  - `actions/setup-node@v2` → [`7c12f801`](https://github.com/actions/setup-node/commit/7c12f8017d5436eb855f1ed4399f037a36fbd9e8)
  - `github/codeql-action/*@v1` → [`231aa2c8`](https://github.com/github/codeql-action/commit/231aa2c8a89117b126725a0e11897209b7118144)

### Dependabot

Added/updated `dependabot.yml` to keep GitHub Actions pinned to the latest SHA with a 7-day update cooldown.


[SECENG-364]: https://hoverinc.atlassian.net/browse/SECENG-364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ